### PR TITLE
feat: normalized payee rejected requests handlers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1405,9 +1405,9 @@
             }
         },
         "node_modules/@mojaloop/platform-shared-lib-public-messages-lib": {
-            "version": "0.5.15",
-            "resolved": "https://registry.npmjs.org/@mojaloop/platform-shared-lib-public-messages-lib/-/platform-shared-lib-public-messages-lib-0.5.15.tgz",
-            "integrity": "sha512-6I/hXZlMymwSgNNT1/IM6X/2McJmWpDNjyNwZD8VVsUuPSrgL4fY88XXTZ88AKTWJLOcjMMjM0qQJL0h0zk8gQ==",
+            "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/@mojaloop/platform-shared-lib-public-messages-lib/-/platform-shared-lib-public-messages-lib-0.5.16.tgz",
+            "integrity": "sha512-zcGVrbxHR2q8Oo03N2ultUITZ32zN6uRRpBqQdxEua7OXs+cq4D0SP3tP+I5tDqU2u6VpxF/qlh9vSSKkrw6uA==",
             "dependencies": {
                 "@mojaloop/platform-shared-lib-messaging-types-lib": "~0.5.6"
             },
@@ -10483,7 +10483,7 @@
             "dependencies": {
                 "@mojaloop/logging-bc-public-types-lib": "~0.5.2",
                 "@mojaloop/platform-shared-lib-messaging-types-lib": "~0.5.4",
-                "@mojaloop/platform-shared-lib-public-messages-lib": "~0.5.15"
+                "@mojaloop/platform-shared-lib-public-messages-lib": "~0.5.16"
             },
             "devDependencies": {
                 "@mojaloop/quoting-bc-shared-mocks-lib": "*"
@@ -10567,7 +10567,7 @@
                 "@mojaloop/logging-bc-public-types-lib": "~0.5.2",
                 "@mojaloop/platform-shared-lib-messaging-types-lib": "~0.5.4",
                 "@mojaloop/platform-shared-lib-nodejs-kafka-client-lib": "~0.5.6",
-                "@mojaloop/platform-shared-lib-public-messages-lib": "~0.5.15",
+                "@mojaloop/platform-shared-lib-public-messages-lib": "~0.5.16",
                 "@mojaloop/quoting-bc-domain-lib": "*",
                 "@mojaloop/quoting-bc-implementations-lib": "*",
                 "@mojaloop/security-bc-client-lib": "~0.5.7",

--- a/packages/domain-lib/package.json
+++ b/packages/domain-lib/package.json
@@ -35,7 +35,7 @@
     "dependencies": {
         "@mojaloop/logging-bc-public-types-lib": "~0.5.2",
         "@mojaloop/platform-shared-lib-messaging-types-lib": "~0.5.4",
-        "@mojaloop/platform-shared-lib-public-messages-lib": "~0.5.15"
+        "@mojaloop/platform-shared-lib-public-messages-lib": "~0.5.16"
     },
     "devDependencies": {
         "@mojaloop/quoting-bc-shared-mocks-lib": "*"

--- a/packages/domain-lib/src/aggregate.ts
+++ b/packages/domain-lib/src/aggregate.ts
@@ -40,12 +40,12 @@ import {
     BulkQuoteReceivedEvt,
     BulkQuoteReceivedEvtPayload,
     BulkQuoteRequestedEvt,
-    GetBulkQuoteQueryRejectedEvt,
-    GetBulkQuoteQueryRejectedResponseEvt,
-    GetBulkQuoteQueryRejectedResponseEvtPayload,
-    GetQuoteQueryRejectedEvt,
-    GetQuoteQueryRejectedResponseEvt,
-    GetQuoteQueryRejectedResponseEvtPayload,
+    BulkQuoteRejectedEvt,
+    BulkQuoteRejectedResponseEvt,
+    BulkQuoteRejectedResponseEvtPayload,
+    QuoteRejectedEvt,
+    QuoteRejectedResponseEvt,
+    QuoteRejectedResponseEvtPayload,
     QuoteBCBulkQuoteExpiredErrorEvent,
     QuoteBCBulkQuoteExpiredErrorPayload,
     QuoteBCBulkQuoteNotFoundErrorEvent,
@@ -204,10 +204,10 @@ export class QuotingAggregate {
                         message as QuoteQueryReceivedEvt
                     );
                     break;
-                case GetQuoteQueryRejectedEvt.name:
+                case QuoteRejectedEvt.name:
                     eventToPublish =
-                        await this.handleGetQuoteQueryRejectedEvent(
-                            message as GetQuoteQueryRejectedEvt
+                        await this.handleQuoteRejectedEvent(
+                            message as QuoteRejectedEvt
                         );
                     break;
                 case BulkQuoteRequestedEvt.name:
@@ -227,10 +227,10 @@ export class QuotingAggregate {
                             message as BulkQuoteQueryReceivedEvt
                         );
                     break;
-                case GetBulkQuoteQueryRejectedEvt.name:
+                case BulkQuoteRejectedEvt.name:
                     eventToPublish =
                         await this.handleGetBulkQuoteQueryRejectedEvent(
-                            message as GetBulkQuoteQueryRejectedEvt
+                            message as BulkQuoteRejectedEvt
                         );
                     break;
                 default: {
@@ -642,11 +642,11 @@ export class QuotingAggregate {
     //#endregion
 
     //#region handleGetQuoteQueryRejectedEvt
-    private async handleGetQuoteQueryRejectedEvent(
-        message: GetQuoteQueryRejectedEvt
+    private async handleQuoteRejectedEvent(
+        message: QuoteRejectedEvt
     ): Promise<DomainEventMsg> {
         this._logger.debug(
-            `Got getQuoteQueryRejected msg for quoteId: ${message.payload.quoteId}`
+            `Got QuoteRejected msg for quoteId: ${message.payload.quoteId}`
         );
 
         const quoteId = message.payload.quoteId;
@@ -680,12 +680,12 @@ export class QuotingAggregate {
             return destinationParticipantError;
         }
 
-        const payload: GetQuoteQueryRejectedResponseEvtPayload = {
+        const payload: QuoteRejectedResponseEvtPayload = {
             quoteId,
             errorInformation: message.payload.errorInformation,
         };
 
-        const event = new GetQuoteQueryRejectedResponseEvt(payload);
+        const event = new QuoteRejectedResponseEvt(payload);
 
         return event;
     }
@@ -1047,7 +1047,7 @@ export class QuotingAggregate {
     //#region handleGetBulkQuoteQueryRejected
 
     private async handleGetBulkQuoteQueryRejectedEvent(
-        message: GetBulkQuoteQueryRejectedEvt
+        message: BulkQuoteRejectedEvt
     ): Promise<DomainEventMsg> {
         this._logger.debug(
             `Got GetBulkQuoteQueryRejected msg for quoteId: ${message.payload.bulkQuoteId}`
@@ -1084,12 +1084,12 @@ export class QuotingAggregate {
             return destinationParticipantError;
         }
 
-        const payload: GetBulkQuoteQueryRejectedResponseEvtPayload = {
+        const payload: BulkQuoteRejectedResponseEvtPayload = {
             bulkQuoteId,
             errorInformation: message.payload.errorInformation,
         };
 
-        const event = new GetBulkQuoteQueryRejectedResponseEvt(payload);
+        const event = new BulkQuoteRejectedResponseEvt(payload);
 
         return event;
     }

--- a/packages/domain-lib/test/unit/aggregate_bulk_quote.test.ts
+++ b/packages/domain-lib/test/unit/aggregate_bulk_quote.test.ts
@@ -46,9 +46,9 @@ import {
     BulkQuoteReceivedEvtPayload,
     BulkQuoteRequestedEvt,
     BulkQuoteRequestedEvtPayload,
-    GetBulkQuoteQueryRejectedEvt,
-    GetBulkQuoteQueryRejectedEvtPayload,
-    GetBulkQuoteQueryRejectedResponseEvt,
+    BulkQuoteRejectedEvt,
+    BulkQuoteRejectedEvtPayload,
+    BulkQuoteRejectedResponseEvt,
 } from "@mojaloop/platform-shared-lib-public-messages-lib";
 import { QuoteState } from "@mojaloop/quoting-bc-public-types-lib";
 import {
@@ -706,7 +706,7 @@ describe("Domain - Unit Tests for Bulk Quote Events", () => {
     test("handleGetBulkQuoteQueryRejectedEvent - it should publish bulk quote with error information", async () => {
         // Arrange
         const mockedBulkQuote = mockedBulkQuote1;
-        const payload: GetBulkQuoteQueryRejectedEvtPayload = {
+        const payload: BulkQuoteRejectedEvtPayload = {
             bulkQuoteId: mockedBulkQuote.bulkQuoteId,
             errorInformation: {
                 errorCode: "3200",
@@ -725,7 +725,7 @@ describe("Domain - Unit Tests for Bulk Quote Events", () => {
 
         const message: IMessage = createMessage(
             payload,
-            GetBulkQuoteQueryRejectedEvt.name,
+            BulkQuoteRejectedEvt.name,
             fspiopOpaqueState
         );
 
@@ -733,7 +733,7 @@ describe("Domain - Unit Tests for Bulk Quote Events", () => {
             null
         );
 
-        //TODO: add extension list to GetBulkQuoteQueryRejectedResponseEvtPayload
+        //TODO: add extension list to BulkQuoteRejectedResponseEvtPayload
         const responsePayload = {
             errorInformation: {
                 errorCode: "3200",
@@ -766,7 +766,7 @@ describe("Domain - Unit Tests for Bulk Quote Events", () => {
         expect(messageProducer.send).toHaveBeenCalledWith(
             expect.objectContaining({
                 payload: responsePayload,
-                msgName: GetBulkQuoteQueryRejectedResponseEvt.name,
+                msgName: BulkQuoteRejectedResponseEvt.name,
                 fspiopOpaqueState,
             })
         );

--- a/packages/domain-lib/test/unit/aggregate_bulk_quote_non_happy_path.test.ts
+++ b/packages/domain-lib/test/unit/aggregate_bulk_quote_non_happy_path.test.ts
@@ -50,7 +50,7 @@ import {
     BulkQuoteQueryReceivedEvt,
     QuoteBCBulkQuoteNotFoundErrorEvent,
     QuoteBCBulkQuoteNotFoundErrorPayload,
-    GetBulkQuoteQueryRejectedEvt,
+    BulkQuoteRejectedEvt,
 } from "@mojaloop/platform-shared-lib-public-messages-lib";
 import {
     createBulkQuotePendingReceivedEvtPayload,
@@ -1593,7 +1593,7 @@ describe("Domain - Unit Tests for Bulk Quote Events, Non Happy Path", () => {
 
         const message: IMessage = createMessage(
             payload,
-            GetBulkQuoteQueryRejectedEvt.name,
+            BulkQuoteRejectedEvt.name,
             fspiopOpaqueState
         );
 

--- a/packages/domain-lib/test/unit/aggregate_quote.test.ts
+++ b/packages/domain-lib/test/unit/aggregate_quote.test.ts
@@ -35,8 +35,8 @@
 import { IMessage } from "@mojaloop/platform-shared-lib-messaging-types-lib";
 import { IParticipant } from "@mojaloop/participant-bc-public-types-lib";
 import {
-    GetQuoteQueryRejectedEvt,
-    GetQuoteQueryRejectedEvtPayload,
+    QuoteRejectedEvt,
+    QuoteRejectedEvtPayload,
     QuoteQueryReceivedEvt,
     QuoteQueryReceivedEvtPayload,
     QuoteQueryResponseEvtPayload,
@@ -651,11 +651,11 @@ describe("Domain - Unit Tests for Quote Events", () => {
 
     //#endregion
 
-    //#region GetQuoteQueryRejectedEvt
-    test("handleGetQuoteQueryRejectedEvent - should publish quote event with error information", async () => {
+    //#region QuoteRejectedEvt
+    test("handleQuoteRejectedEvent - should publish quote event with error information", async () => {
         // Arrange
         const mockedQuote = mockedQuote1;
-        const payload: GetQuoteQueryRejectedEvtPayload =
+        const payload: QuoteRejectedEvtPayload =
             createQuoteQueryRejectedEvtPayload(mockedQuote);
 
         const requesterFspId = mockedQuote.payer.partyIdInfo.fspId;
@@ -668,11 +668,11 @@ describe("Domain - Unit Tests for Quote Events", () => {
 
         const message: IMessage = createMessage(
             payload,
-            GetQuoteQueryRejectedEvt.name,
+            QuoteRejectedEvt.name,
             fspiopOpaqueState
         );
 
-        const payloadResponse: GetQuoteQueryRejectedEvtPayload = {
+        const payloadResponse: QuoteRejectedEvtPayload = {
             quoteId: mockedQuote.quoteId,
             errorInformation: mockedQuote.errorInformation as any,
         };

--- a/packages/domain-lib/test/unit/aggregate_quote_non_happy_path.test.ts
+++ b/packages/domain-lib/test/unit/aggregate_quote_non_happy_path.test.ts
@@ -50,7 +50,7 @@ import {
     createQuoteResponseReceivedEvtPayload,
 } from "../utils/helpers";
 import {
-    GetQuoteQueryRejectedEvt,
+    QuoteRejectedEvt,
     QuoteBCDestinationParticipantNotFoundErrorEvent,
     QuoteBCDestinationParticipantNotFoundErrorPayload,
     QuoteBCInvalidDestinationFspIdErrorEvent,
@@ -1623,7 +1623,7 @@ describe("Domain - Unit Tests for Quote Events, Non Happy Path", () => {
     //#endregion
 
     //#region handleGetQuoteQueryRejectedEvt
-    test("handleGetQuoteQueryRejectedEvent - should send error event if quote is rejected due to invalid requester fsp", async () => {
+    test("handleQuoteRejectedEvent - should send error event if quote is rejected due to invalid requester fsp", async () => {
         const mockedQuote = mockedQuote1;
         const requesterFspId = null;
         const destinationFspId = mockedQuote.payee.partyIdInfo.fspId;
@@ -1631,7 +1631,7 @@ describe("Domain - Unit Tests for Quote Events, Non Happy Path", () => {
 
         const message: IMessage = createMessage(
             payload,
-            GetQuoteQueryRejectedEvt.name,
+            QuoteRejectedEvt.name,
             {
                 requesterFspId,
                 destinationFspId,
@@ -1660,7 +1660,7 @@ describe("Domain - Unit Tests for Quote Events, Non Happy Path", () => {
         );
     });
 
-    test("handleGetQuoteQueryRejectedEvent - should send error event if quote is rejected due to invalid destination fsp", async () => {
+    test("handleQuoteRejectedEvent - should send error event if quote is rejected due to invalid destination fsp", async () => {
         const mockedQuote = mockedQuote1;
         const requesterFspId = mockedQuote.payer.partyIdInfo.fspId;
         const destinationFspId = null;
@@ -1668,7 +1668,7 @@ describe("Domain - Unit Tests for Quote Events, Non Happy Path", () => {
 
         const message: IMessage = createMessage(
             payload,
-            GetQuoteQueryRejectedEvt.name,
+            QuoteRejectedEvt.name,
             {
                 requesterFspId,
                 destinationFspId,

--- a/packages/domain-lib/test/utils/helpers.ts
+++ b/packages/domain-lib/test/utils/helpers.ts
@@ -39,12 +39,9 @@ import {
 import {
     QuoteResponseReceivedEvtPayload,
     QuoteRequestReceivedEvtPayload,
-    BulkQuotePendingReceivedEvt,
     BulkQuotePendingReceivedEvtPayload,
     BulkQuoteRequestedEvtPayload,
-    GetQuoteQueryRejectedResponseEvtPayload,
     QuoteRejectedEvtPayload,
-    BulkQuoteQueryReceivedEvt,
     BulkQuoteQueryReceivedEvtPayload,
     QuoteQueryReceivedEvtPayload,
     BulkQuoteRejectedEvtPayload,

--- a/packages/domain-lib/test/utils/helpers.ts
+++ b/packages/domain-lib/test/utils/helpers.ts
@@ -43,11 +43,11 @@ import {
     BulkQuotePendingReceivedEvtPayload,
     BulkQuoteRequestedEvtPayload,
     GetQuoteQueryRejectedResponseEvtPayload,
-    GetQuoteQueryRejectedEvtPayload,
+    QuoteRejectedEvtPayload,
     BulkQuoteQueryReceivedEvt,
     BulkQuoteQueryReceivedEvtPayload,
     QuoteQueryReceivedEvtPayload,
-    GetBulkQuoteQueryRejectedEvtPayload,
+    BulkQuoteRejectedEvtPayload,
 } from "@mojaloop/platform-shared-lib-public-messages-lib";
 import { IBulkQuote, IMoney, IQuote } from "@mojaloop/quoting-bc-public-types-lib";
 
@@ -105,7 +105,7 @@ export function createQuoteQueryReceivedEvtPayload(
 
 export function createQuoteQueryRejectedEvtPayload(
     mockedQuote: IQuote
-): GetQuoteQueryRejectedEvtPayload {
+): QuoteRejectedEvtPayload {
     const quote = Object.assign({}, mockedQuote);
     return {
         quoteId: quote.quoteId,
@@ -160,7 +160,7 @@ export function createBulkQuoteQueryRejectedEvtPayload(
             }[];
         } | null;
     }
-): GetBulkQuoteQueryRejectedEvtPayload {
+): BulkQuoteRejectedEvtPayload {
     const bulkQuote = Object.assign({}, mockedBulkQuote);
     return {
         bulkQuoteId: bulkQuote.bulkQuoteId,

--- a/packages/quoting-svc/package.json
+++ b/packages/quoting-svc/package.json
@@ -46,7 +46,7 @@
         "@mojaloop/logging-bc-public-types-lib": "~0.5.2",
         "@mojaloop/platform-shared-lib-nodejs-kafka-client-lib": "~0.5.6",
         "@mojaloop/platform-shared-lib-messaging-types-lib": "~0.5.4",
-        "@mojaloop/platform-shared-lib-public-messages-lib": "~0.5.15",
+        "@mojaloop/platform-shared-lib-public-messages-lib": "~0.5.16",
         "@mojaloop/security-bc-client-lib": "~0.5.7",
         "@mojaloop/security-bc-public-types-lib": "~0.5.5",
         "@mojaloop/quoting-bc-domain-lib": "*",


### PR DESCRIPTION
Required changes to maintain the same error code structure across all BCs that communicate with the interop-api:

[#Issue 3465](https://app.zenhub.com/workspaces/mojaloop-project-59edee71d1407922110cf083/issues/gh/mojaloop/project/3465)